### PR TITLE
Caviat added when using the attribute DownloadPath

### DIFF
--- a/DeployOffice/configuration-options-for-the-office-2016-deployment-tool.md
+++ b/DeployOffice/configuration-options-for-the-office-2016-deployment-tool.md
@@ -149,6 +149,7 @@ Example values:
   </Product>
 </Add>  
 ```
+Note that you must specify a Version when using DownloadPath.
 
 ### AllowCdnFallback attribute (part of Add element) 
 


### PR DESCRIPTION
as per:- 
https://docs.microsoft.com/en-us/deployoffice/overview-of-the-office-2016-deployment-tool#download-the-installation-files-for-office-365-proplus-from-a-local-source
the version should be specified when using the DownloadPath atribute